### PR TITLE
added inline fragment as a valid name

### DIFF
--- a/field.go
+++ b/field.go
@@ -97,7 +97,7 @@ func (f *Field) check() error {
 // checkOther checks the validity of this Field and returns nil on valid Field.
 func (f *Field) checkOther() error {
 	// Check validity of names
-	if !validName.MatchString(f.Name) {
+	if !validName.MatchString(f.Name) && !validInlineFragment.MatchString(f.Name){
 		return errors.WithStack(InvalidNameErr{fieldName, f.Name})
 	}
 	if err := f.checkAlias(); err != nil {

--- a/field_test.go
+++ b/field_test.go
@@ -13,3 +13,8 @@ func TestField_AddArguments(t *testing.T) {
 	f.AddArguments(ArgumentBool("b", true))
 	assert.Equal(t, Argument{"b", argBool(true)}, f.Arguments[0])
 }
+
+func TestField_CheckInlineFragment(t *testing.T) {
+	f := MakeField("... on f")
+	assert.NoError(t, f.checkOther())
+}

--- a/private.go
+++ b/private.go
@@ -8,6 +8,9 @@ import (
 // checks the validity of a name according to the spec: http://facebook.github.io/graphql/October2016/#sec-Names
 var validName = regexp.MustCompile("^[_A-Za-z][_0-9A-Za-z]*$")
 
+// check the validity of an inline fragment as a name according to the spec: https://graphql.github.io/graphql-spec/June2018/#sec-Inline-Fragments
+var validInlineFragment = regexp.MustCompile("^... on [_A-Za-z][_0-9A-Za-z]*$")
+
 func isValidOperationType(Type operationType) bool {
 	low := strings.ToLower(string(Type))
 	return low == "query" || low == "mutation" || low == "subscription"


### PR DESCRIPTION
we need to test out a query that uses inline fragment which is not allowed with the current valid name check. This PR does not include directive support.